### PR TITLE
default exportとexport

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import ColorfulMessage from "./components/ColorfulMessage";
+import { ColorfulMessage } from "./components/ColorfulMessage";
 
 const App = () => {
   console.log("最初");

--- a/src/components/ColorfulMessage.jsx
+++ b/src/components/ColorfulMessage.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const ColorfulMeaages = (props) => {
+export const ColorfulMessage = (props) => {
   const { color, children } = props;
   const contentStyle = {
     color,
@@ -8,5 +8,3 @@ const ColorfulMeaages = (props) => {
   };
   return <p style={contentStyle}>{children}</p>;
 };
-
-export default ColorfulMeaages;


### PR DESCRIPTION
## default exportとexportの違い
- コンポーネントをdefault exportした場合、親側でそのコンポーネントをimportした際には任意の名前をつけられるため、typoしてもエラーにならない
- 一方、exportした場合は、typoしていると `XXX is not defined`としてエラーするので、正しいコンポーネント名に統一することができる
- どちらもよく使われるので好みではあるが、プロジェクト内でコードスタイリングとして統一しておくといいかなと。